### PR TITLE
Remove rappdirs as dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             R -e "install.packages('DT')"
       - run:
           command: |
-            R -e "devtools::check(cran = FALSE, args = c('--run-donttest')"
+            R -e "devtools::check(cran = FALSE, args = c('--run-donttest'))"
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "DESCRIPTION" }}-{{ checksum ".circleci/config.yml" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             R -e "install.packages('DT')"
       - run:
           command: |
-            R -e 'devtools::check(cran = FALSE)'
+            R -e "devtools::check(cran = FALSE, args = c('--run-donttest')"
       - save_cache:
           key: deps1-{{ .Branch }}-{{ checksum "DESCRIPTION" }}-{{ checksum ".circleci/config.yml" }}
           paths:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R:
            family = "Joseph",
            role = c("aut", "cre"),
            email = "maxwell.b.joseph@colorado.edu")
-Description: The eddi package allows users to easily acquire and work with the 
+Description: Allows users to easily acquire and work with the 
   National Oceanographic and Atmospheric Administration Evaporative Demand 
   Drought Index (EDDI) data product, which is useful for detecting drought at 
   multiple time scales, from weekly "flash droughts" to month-spanning 
@@ -20,7 +20,6 @@ Encoding: UTF-8
 LazyData: true
 Imports: 
     raster,
-    rappdirs,
     rgdal,
     utils
 RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,10 +6,9 @@ Authors@R:
            family = "Joseph",
            role = c("aut", "cre"),
            email = "maxwell.b.joseph@colorado.edu")
-Description: Allows users to easily acquire and work with the 
-  National Oceanographic and Atmospheric Administration Evaporative Demand 
-  Drought Index (EDDI) data product, which is useful for detecting drought at 
-  multiple time scales, from weekly "flash droughts" to month-spanning 
+Description: Acquire and work with the National Oceanographic and Atmospheric 
+  Administration Evaporative Demand Drought Index (EDDI) data product, which 
+  detects drought at multiple time scales, from weekly "flash droughts" to 
   long-term droughts. This package finds and downloads raw EDDI data, 
   then reads the data into R using the raster package. More information about
   the EDDI data product can be found at <https://www.esrl.noaa.gov/psd/eddi/>.

--- a/R/get_eddi.R
+++ b/R/get_eddi.R
@@ -19,19 +19,19 @@
 #' be rounded to the nearest integer (e.g., "1.1 week" will be converted to
 #' "1 week").
 #' @param dir Directory to for downloaded EDDI data. By default this will be
-#' your cache directory. This should be a file path specified as a string.
+#' a temporary directory. This should be a file path specified as a string.
 #' @param overwrite Boolean to indicate whether to overwrite EDDI data that
 #' already exist locally in \code{dir}. Defaults to FALSE.
 #' @return A Raster* object containing EDDI data. Each layer in this object
 #' corresponds to data for one date.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' get_eddi(date = "2018-01-01", timescale = "1 month")
 #' }
 #'
 #' @export
-get_eddi <- function(date, timescale, dir = NA, overwrite = FALSE) {
+get_eddi <- function(date, timescale, dir = tempdir(), overwrite = FALSE) {
   parsed_date <- parse_date(date)
   parsed_timescale <- parse_timescale(timescale)
   ts_unit_abbrev <- ifelse(parsed_timescale[['units']] == 'week', 'wk', 'mn')
@@ -42,9 +42,6 @@ get_eddi <- function(date, timescale, dir = NA, overwrite = FALSE) {
     "EDDI_ETrs_", parsed_timescale[["number"]], ts_unit_abbrev,
     "_", format(parsed_date, "%Y%m%d"), ".asc"
   )
-  if (is.na(dir)) {
-    dir <- rappdirs::user_cache_dir()
-  }
   local_path <- file.path(dir, basename(url))
   for (i in seq_along(url)) {
     if (overwrite | !file.exists(local_path[i])) {

--- a/codemeta.json
+++ b/codemeta.json
@@ -5,7 +5,7 @@
   ],
   "@type": "SoftwareSourceCode",
   "identifier": "eddi",
-  "description": "The eddi package allows users to easily acquire and work with the \n  National Oceanographic and Atmospheric Administration Evaporative Demand \n  Drought Index (EDDI) data product, which is useful for detecting drought at \n  multiple time scales, from weekly \"flash droughts\" to month-spanning \n  long-term droughts. This package finds and downloads raw EDDI data, \n  then reads the data into R using the raster package. More information about\n  the EDDI data product can be found at <https://www.esrl.noaa.gov/psd/eddi/>.",
+  "description": "Allows users to easily acquire and work with the \n  National Oceanographic and Atmospheric Administration Evaporative Demand \n  Drought Index (EDDI) data product, which is useful for detecting drought at \n  multiple time scales, from weekly \"flash droughts\" to month-spanning \n  long-term droughts. This package finds and downloads raw EDDI data, \n  then reads the data into R using the raster package. More information about\n  the EDDI data product can be found at <https://www.esrl.noaa.gov/psd/eddi/>.",
   "name": "eddi: Get Evaporative Demand Drought Index Raster Data",
   "codeRepository": "https://github.com/earthlab/eddi",
   "issueTracker": "https://github.com/earthlab/eddi/issues",
@@ -99,18 +99,6 @@
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "rappdirs",
-      "name": "rappdirs",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Comprehensive R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      },
-      "sameAs": "https://CRAN.R-project.org/package=rappdirs"
-    },
-    {
-      "@type": "SoftwareApplication",
       "identifier": "rgdal",
       "name": "rgdal",
       "provider": {
@@ -129,7 +117,7 @@
   ],
   "releaseNotes": "https://github.com/earthlab/eddi/blob/master/NEWS.md",
   "readme": "https://github.com/earthlab/eddi/blob/master/README.md",
-  "fileSize": "86.718KB",
+  "fileSize": "86.774KB",
   "contIntegration": [
     "https://circleci.com/gh/earthlab/eddi/tree/master",
     "https://codecov.io/gh/earthlab/eddi"

--- a/man/get_eddi.Rd
+++ b/man/get_eddi.Rd
@@ -4,7 +4,7 @@
 \alias{get_eddi}
 \title{Get EDDI data}
 \usage{
-get_eddi(date, timescale, dir = NA, overwrite = FALSE)
+get_eddi(date, timescale, dir = tempdir(), overwrite = FALSE)
 }
 \arguments{
 \item{date}{An object of class Date or a character string formatted as
@@ -20,7 +20,7 @@ be rounded to the nearest integer (e.g., "1.1 week" will be converted to
 "1 week").}
 
 \item{dir}{Directory to for downloaded EDDI data. By default this will be
-your cache directory. This should be a file path specified as a string.}
+a temporary directory. This should be a file path specified as a string.}
 
 \item{overwrite}{Boolean to indicate whether to overwrite EDDI data that
 already exist locally in \code{dir}. Defaults to FALSE.}
@@ -40,7 +40,7 @@ multiple timescales, including the 1 to 12 week and 1 to 12 months scales.
 For more information see \url{https://www.esrl.noaa.gov/psd/eddi/}
 }
 \examples{
-\dontrun{
+\donttest{
 get_eddi(date = "2018-01-01", timescale = "1 month")
 }
 

--- a/tests/testthat/test-get_eddi.R
+++ b/tests/testthat/test-get_eddi.R
@@ -39,17 +39,17 @@ test_that("Timescale units other than 'week' or 'month' raise errors", {
 
 test_that("Single dates return RasterStacks", {
   skip_on_cran()
-  r <- get_eddi(date = "2018-11-29", timescale = "1 month", dir = '.')
+  r <- get_eddi(date = "2018-11-29", timescale = "1 month", dir = ".")
   expect_is(r, "RasterStack")
   expect_equal(raster::nlayers(r), 1)
+  expect_true(file.exists("EDDI_ETrs_01mn_20181129.asc"))
   unlink(list.files(pattern = "*.asc"))
 })
 
 test_that("Multiple dates return RasterStacks", {
   skip_on_cran()
   dates <- seq(as.Date("2017-12-31"), as.Date("2018-01-01"), by = 1)
-  r <- get_eddi(date = dates, timescale = "1 month", dir = '.')
+  r <- get_eddi(date = dates, timescale = "1 month")
   expect_is(r, "RasterStack")
   expect_equal(raster::nlayers(r), 2)
-  unlink(list.files(pattern = "*.asc"))
 })


### PR DESCRIPTION
CRAN submission flagged the usage of the user's cache dir to save output. This PR uses tempdir() instead, which eliminates rappdirs as a dependency.