### PR TITLE
Add call to rgdal to eliminate note

### DIFF
--- a/R/get_eddi.R
+++ b/R/get_eddi.R
@@ -32,6 +32,7 @@
 #'
 #' @export
 get_eddi <- function(date, timescale, dir = tempdir(), overwrite = FALSE) {
+  rgdal::getGDALCheckVersion()
   parsed_date <- parse_date(date)
   parsed_timescale <- parse_timescale(timescale)
   ts_unit_abbrev <- ifelse(parsed_timescale[['units']] == 'week', 'wk', 'mn')


### PR DESCRIPTION
The note about rgdal not being used is a false positive, because rgdal is used by the raster package, and reading datasets does not work unless rgdal is installed.